### PR TITLE
Fixed getLoadedDataFrameNames to find objects coercible to a dataframe

### DIFF
--- a/inst/raptR/functions/helper.R
+++ b/inst/raptR/functions/helper.R
@@ -75,7 +75,7 @@ getLoadedDataFrameNames <- function(env=.GlobalEnv) {
   dfNames <- c()
   for (objName in objNames) {
     obj <- get(objName)
-    if(class(obj)=='data.frame') {
+    if(is.data.frame(obj)) {
       dfNames <- c(dfNames, objName)
     } 
   }


### PR DESCRIPTION
`class(obj)=='data.frame'` will only check if `obj` is a dataframe, rather than if it can be coerced into a dataframe. This is an issue when using dplyr to group/summarise/etc. since the class of the object will not be a dataframe, even though it will behave as a dataframe.
